### PR TITLE
Fix GitHub Pages workflow working directory

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,6 +17,9 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: app
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -25,7 +28,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'npm'
+          cache: npm
+          cache-dependency-path: app/package-lock.json
 
       - name: Install deps
         run: npm ci
@@ -41,7 +45,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: dist
+          path: app/dist
 
   deploy:
     environment:


### PR DESCRIPTION
## Summary
- configure the build job to run npm commands from the app directory
- adjust Node cache settings to use the application's lockfile
- upload the built site from the correct app/dist folder for deployment

## Testing
- npm install
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc4e3e88588331b62c947818584cdc