### PR TITLE
Configure Vite base path for GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,8 +35,7 @@ jobs:
         run: npm ci
 
       - name: Build (Vite)
-        # base をリポジトリ名に自動設定し、サブパス公開に対応
-        run: npm run build -- --base="/${{ github.event.repository.name }}/"
+        run: npm run build
 
       - name: SPA fallback (404.html)
         # React Router などの SPA 対応: 404.html を index.html のコピーとして用意

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -1,7 +1,14 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
+const repository = (globalThis as typeof globalThis & {
+  process?: { env?: Record<string, string | undefined> }
+}).process?.env?.GITHUB_REPOSITORY
+const repoName = repository?.split('/')?.[1]
+const base = repoName ? `/${repoName}/` : '/'
+
 // https://vite.dev/config/
 export default defineConfig({
+  base,
   plugins: [react()],
 })


### PR DESCRIPTION
## Summary
- derive the Vite `base` option from the `GITHUB_REPOSITORY` environment variable so hashed assets load from the correct GitHub Pages subpath
- simplify the GitHub Pages workflow by calling `npm run build` without needing to pass a manual `--base`

## Testing
- GITHUB_REPOSITORY=owner/HexViewer npm run build


------
https://chatgpt.com/codex/tasks/task_e_68cc51138034833188c7680803d2bc3c