### PR TITLE
Fix GitHub Pages rendering by caching Zustand selectors

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -4,14 +4,17 @@ import { TreePanel } from "./components/TreePanel";
 import { HexPane } from "./components/HexPane";
 import { KsyEditor } from "./components/KsyEditor";
 import { useSessionStore } from "./state/sessionStore";
+import { useShallow } from "zustand/react/shallow";
 
 function StatusBar() {
-  const { selectedRange, fileMeta, buffer, caret } = useSessionStore((state) => ({
-    selectedRange: state.selectedRange,
-    fileMeta: state.fileMeta,
-    buffer: state.buffer,
-    caret: state.caret,
-  }));
+  const { selectedRange, fileMeta, buffer, caret } = useSessionStore(
+    useShallow((state) => ({
+      selectedRange: state.selectedRange,
+      fileMeta: state.fileMeta,
+      buffer: state.buffer,
+      caret: state.caret,
+    })),
+  );
 
   const selectionText = selectedRange
     ? `${selectedRange.start} (+0x${selectedRange.start.toString(16)}) / ${selectedRange.length} bytes`

--- a/app/src/components/HexPane.tsx
+++ b/app/src/components/HexPane.tsx
@@ -6,6 +6,7 @@ import {
   useState,
 } from "react";
 import { useSessionStore } from "../state/sessionStore";
+import { useShallow } from "zustand/react/shallow";
 
 const ROW_HEIGHT = 24;
 const OVERSCAN = 12;
@@ -20,14 +21,14 @@ function isPrintable(byte: number): boolean {
 
 export function HexPane() {
   const { buffer, selectedRange, selectRange, hexCols, editByte, caret } = useSessionStore(
-    (state) => ({
+    useShallow((state) => ({
       buffer: state.buffer,
       selectedRange: state.selectedRange,
       selectRange: state.selectRange,
       hexCols: state.hexCols,
       editByte: state.editByte,
       caret: state.caret,
-    })
+    })),
   );
   const [hexInput, setHexInput] = useState("");
   const [asciiInput, setAsciiInput] = useState("");

--- a/app/src/components/KsyEditor.tsx
+++ b/app/src/components/KsyEditor.tsx
@@ -1,11 +1,14 @@
 import { useSessionStore } from "../state/sessionStore";
+import { useShallow } from "zustand/react/shallow";
 
 export function KsyEditor() {
-  const { ksySource, setKsySource, applyKsy } = useSessionStore((state) => ({
-    ksySource: state.ksySource,
-    setKsySource: state.setKsySource,
-    applyKsy: state.applyKsy,
-  }));
+  const { ksySource, setKsySource, applyKsy } = useSessionStore(
+    useShallow((state) => ({
+      ksySource: state.ksySource,
+      setKsySource: state.setKsySource,
+      applyKsy: state.applyKsy,
+    })),
+  );
 
   return (
     <section className="ksy-editor">

--- a/app/src/components/TopBar.tsx
+++ b/app/src/components/TopBar.tsx
@@ -1,5 +1,6 @@
 import { useRef } from "react";
 import { useSessionStore } from "../state/sessionStore";
+import { useShallow } from "zustand/react/shallow";
 
 const SAMPLE_HEX = "4865585612340000000000000000000000000000000000000000000000000000";
 const SAMPLE_BYTES = Uint8Array.from(
@@ -41,21 +42,23 @@ export function TopBar() {
     setHexCols,
     fileMeta,
     errors,
-  } = useSessionStore((state) => ({
-    loadFile: state.loadFile,
-    applyKsy: state.applyKsy,
-    undo: state.undo,
-    redo: state.redo,
-    saveSession: state.saveSession,
-    restoreSession: state.restoreSession,
-    setBuffer: state.setBuffer,
-    setKsySource: state.setKsySource,
-    ksySource: state.ksySource,
-    hexCols: state.hexCols,
-    setHexCols: state.setHexCols,
-    fileMeta: state.fileMeta,
-    errors: state.errors,
-  }));
+  } = useSessionStore(
+    useShallow((state) => ({
+      loadFile: state.loadFile,
+      applyKsy: state.applyKsy,
+      undo: state.undo,
+      redo: state.redo,
+      saveSession: state.saveSession,
+      restoreSession: state.restoreSession,
+      setBuffer: state.setBuffer,
+      setKsySource: state.setKsySource,
+      ksySource: state.ksySource,
+      hexCols: state.hexCols,
+      setHexCols: state.setHexCols,
+      fileMeta: state.fileMeta,
+      errors: state.errors,
+    })),
+  );
 
   const handleFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];

--- a/app/src/components/TreePanel.tsx
+++ b/app/src/components/TreePanel.tsx
@@ -1,12 +1,15 @@
 import { useMemo, useState } from "react";
 import type { AstNode } from "../types";
 import { useSessionStore } from "../state/sessionStore";
+import { useShallow } from "zustand/react/shallow";
 
 function NodeItem({ node, depth }: { node: AstNode; depth: number }) {
-  const { selectedNodeId, selectNode } = useSessionStore((state) => ({
-    selectedNodeId: state.selectedNodeId,
-    selectNode: state.selectNode,
-  }));
+  const { selectedNodeId, selectNode } = useSessionStore(
+    useShallow((state) => ({
+      selectedNodeId: state.selectedNodeId,
+      selectNode: state.selectNode,
+    })),
+  );
   const [expanded, setExpanded] = useState(depth < 2);
   const hasChildren = (node.children?.length ?? 0) > 0;
   const isSelected = selectedNodeId === node.id;
@@ -79,10 +82,12 @@ function NodeDetails({ node }: { node: AstNode }) {
 }
 
 export function TreePanel() {
-  const { parseResult, selectedNodeId } = useSessionStore((state) => ({
-    parseResult: state.parseResult,
-    selectedNodeId: state.selectedNodeId,
-  }));
+  const { parseResult, selectedNodeId } = useSessionStore(
+    useShallow((state) => ({
+      parseResult: state.parseResult,
+      selectedNodeId: state.selectedNodeId,
+    })),
+  );
 
   const selectedNode = useMemo(() => {
     if (!parseResult?.root) return null;


### PR DESCRIPTION
## Summary
- switch multi-field Zustand selectors to `useShallow` so React 19 reuses cached snapshots
- update App, TopBar, TreePanel, HexPane, and KsyEditor to use the helper and avoid the infinite re-render loop that blanked the page

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc56b40538833180d45dcc3907b25e