### PR TITLE
Fix hex pane address column layout

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -262,8 +262,9 @@
 
 .hex-row {
   display: grid;
-  grid-template-columns: 100px 1fr 160px;
+  grid-template-columns: max-content minmax(0, 1fr) max-content;
   align-items: center;
+  column-gap: 1.5rem;
   padding: 0.1rem 0.75rem;
   font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
     "Liberation Mono", "Courier New", monospace;
@@ -273,16 +274,19 @@
 .hex-row__offset {
   color: var(--muted);
   font-size: 0.8rem;
+  font-variant-numeric: tabular-nums;
 }
 
 .hex-row__bytes,
 .hex-row__ascii {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(28px, 1fr));
+  grid-auto-flow: column;
+  grid-auto-columns: max-content;
   gap: 0.25rem;
 }
 
 .hex-row__ascii {
+  justify-content: center;
   justify-items: center;
 }
 


### PR DESCRIPTION
## Summary
- adjust hex pane grid layout so address/hex/ascii columns size to their content
- ensure address digits use tabular figures for consistent spacing
- prevent hex/ascii byte cells from wrapping which caused overlapping rows

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc5dabea30833194f22505a9a2f1d7