### PR TITLE
Enable scrolling in hex dump pane

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -260,7 +260,7 @@
   border: 1px solid var(--panel-border);
   border-radius: 8px;
   background: rgba(0, 0, 0, 0.4);
-  overflow: hidden;
+  overflow: auto;
 }
 
 .hex-pane__list--virtual {


### PR DESCRIPTION
## Summary
- allow the hex dump pane container to scroll by default

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc67f887148331961079761e9550f4