### PR TITLE
Add resizable split panes to editor layout

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -43,10 +43,65 @@
 
 .app-main {
   flex: 1;
-  display: grid;
-  grid-template-columns: minmax(320px, 1fr) 2fr;
-  gap: 0;
+  display: flex;
   overflow: hidden;
+}
+
+.split-pane {
+  display: grid;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+.split-pane--dragging {
+  user-select: none;
+}
+
+.split-pane__pane {
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.split-pane__divider {
+  position: relative;
+  background: rgba(95, 179, 255, 0.2);
+  transition: background 0.2s ease;
+}
+
+.split-pane__divider::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  opacity: 0.75;
+}
+
+.split-pane__divider--horizontal {
+  cursor: row-resize;
+}
+
+.split-pane__divider--horizontal::after {
+  background: linear-gradient(180deg, rgba(95, 179, 255, 0.35), rgba(95, 179, 255, 0));
+}
+
+.split-pane__divider--vertical {
+  cursor: col-resize;
+}
+
+.split-pane__divider--vertical::after {
+  background: linear-gradient(90deg, rgba(95, 179, 255, 0.35), rgba(95, 179, 255, 0));
+}
+
+.split-pane__divider:hover,
+.split-pane__divider--dragging {
+  background: rgba(95, 179, 255, 0.35);
+}
+
+.split-pane__divider--dragging::after {
+  opacity: 1;
 }
 
 .left-pane,
@@ -59,6 +114,11 @@
 .left-pane {
   border-right: 1px solid var(--panel-border);
   background: var(--panel-bg);
+}
+
+.left-pane--stacked {
+  border-right: none;
+  border-bottom: 1px solid var(--panel-border);
 }
 
 .right-pane {
@@ -203,10 +263,16 @@
   padding: 1rem;
   border-top: 1px solid var(--panel-border);
   background: rgba(0, 0, 0, 0.18);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
 .ksy-editor textarea {
   width: 100%;
+  flex: 1;
+  min-height: 0;
+  resize: none;
   font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
     "Liberation Mono", "Courier New", monospace;
   font-size: 0.9rem;
@@ -215,7 +281,6 @@
   border: 1px solid var(--panel-border);
   border-radius: 8px;
   padding: 0.75rem;
-  margin-bottom: 0.75rem;
 }
 
 .ksy-editor button {
@@ -344,12 +409,10 @@
 
 @media (max-width: 960px) {
   .app-main {
-    grid-template-columns: 1fr;
+    flex-direction: column;
   }
 
   .left-pane {
     border-right: none;
-    border-bottom: 1px solid var(--panel-border);
-    max-height: 40vh;
   }
 }

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,8 +1,10 @@
+import { useEffect, useState } from "react";
 import "./App.css";
 import { TopBar } from "./components/TopBar";
 import { TreePanel } from "./components/TreePanel";
 import { HexPane } from "./components/HexPane";
 import { KsyEditor } from "./components/KsyEditor";
+import { SplitPane } from "./components/SplitPane";
 import { useSessionStore } from "./state/sessionStore";
 import { useShallow } from "zustand/react/shallow";
 
@@ -32,18 +34,50 @@ function StatusBar() {
   );
 }
 
+function useMediaQuery(query: string) {
+  const getMatches = () =>
+    typeof window !== "undefined" ? window.matchMedia(query).matches : false;
+
+  const [matches, setMatches] = useState(getMatches);
+
+  useEffect(() => {
+    const mediaQueryList = window.matchMedia(query);
+    const listener = (event: MediaQueryListEvent) => setMatches(event.matches);
+
+    setMatches(mediaQueryList.matches);
+    mediaQueryList.addEventListener("change", listener);
+
+    return () => mediaQueryList.removeEventListener("change", listener);
+  }, [query]);
+
+  return matches;
+}
+
 function App() {
+  const isNarrow = useMediaQuery("(max-width: 960px)");
+  const mainSplitDirection = isNarrow ? "vertical" : "horizontal";
+  const leftPaneClassName = `left-pane${isNarrow ? " left-pane--stacked" : ""}`;
+
   return (
     <div className="app-container">
       <TopBar />
       <main className="app-main">
-        <div className="left-pane">
-          <TreePanel />
-          <KsyEditor />
-        </div>
-        <div className="right-pane">
-          <HexPane />
-        </div>
+        <SplitPane
+          direction={mainSplitDirection}
+          initialRatio={isNarrow ? 0.52 : 0.38}
+          min={0.22}
+          max={0.78}
+        >
+          <div className={leftPaneClassName}>
+            <SplitPane direction="vertical" initialRatio={0.6} min={0.2} max={0.8}>
+              <TreePanel />
+              <KsyEditor />
+            </SplitPane>
+          </div>
+          <div className="right-pane">
+            <HexPane />
+          </div>
+        </SplitPane>
       </main>
       <StatusBar />
     </div>

--- a/app/src/components/SplitPane.tsx
+++ b/app/src/components/SplitPane.tsx
@@ -1,0 +1,100 @@
+import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
+
+type SplitPaneProps = {
+  direction: "horizontal" | "vertical";
+  children: [ReactNode, ReactNode];
+  /** 最初のペインの比率 (0-1) */
+  initialRatio?: number;
+  /** 最初のペインの最小比率 */
+  min?: number;
+  /** 最初のペインの最大比率 */
+  max?: number;
+  className?: string;
+};
+
+const clamp = (value: number, min: number, max: number) => {
+  return Math.min(Math.max(value, min), max);
+};
+
+export function SplitPane({
+  direction,
+  children,
+  initialRatio = 0.5,
+  min = 0.2,
+  max = 0.8,
+  className,
+}: SplitPaneProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [ratio, setRatio] = useState(() => clamp(initialRatio, min, max));
+  const [isDragging, setIsDragging] = useState(false);
+
+  useEffect(() => {
+    setRatio(clamp(initialRatio, min, max));
+  }, [direction, initialRatio, min, max]);
+
+  useEffect(() => {
+    if (!isDragging) return;
+
+    function handleMouseMove(event: MouseEvent) {
+      if (!containerRef.current) return;
+      const rect = containerRef.current.getBoundingClientRect();
+
+      const nextRatio = clamp(
+        direction === "horizontal"
+          ? (event.clientX - rect.left) / rect.width
+          : (event.clientY - rect.top) / rect.height,
+        min,
+        max,
+      );
+
+      setRatio(nextRatio);
+      event.preventDefault();
+    }
+
+    function handleMouseUp() {
+      setIsDragging(false);
+    }
+
+    window.addEventListener("mousemove", handleMouseMove);
+    window.addEventListener("mouseup", handleMouseUp);
+
+    return () => {
+      window.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("mouseup", handleMouseUp);
+    };
+  }, [direction, isDragging, min, max]);
+
+  const dividerSize = useMemo(() => (direction === "horizontal" ? 8 : 6), [direction]);
+
+  const templateStyle = useMemo(() => {
+    const first = Math.max(ratio, 0.0001);
+    const second = Math.max(1 - ratio, 0.0001);
+
+    if (direction === "horizontal") {
+      return { gridTemplateColumns: `${first}fr ${dividerSize}px ${second}fr` };
+    }
+    return { gridTemplateRows: `${first}fr ${dividerSize}px ${second}fr` };
+  }, [direction, dividerSize, ratio]);
+
+  const paneClass = `split-pane split-pane--${direction} ${isDragging ? "split-pane--dragging" : ""} ${
+    className ?? ""
+  }`;
+
+  const dividerClass = `split-pane__divider split-pane__divider--${direction === "horizontal" ? "vertical" : "horizontal"} ${
+    isDragging ? "split-pane__divider--dragging" : ""
+  }`;
+
+  return (
+    <div ref={containerRef} className={paneClass.trim()} style={templateStyle}>
+      <div className="split-pane__pane">{children[0]}</div>
+      <div
+        className={dividerClass.trim()}
+        onMouseDown={(event) => {
+          event.preventDefault();
+          setIsDragging(true);
+        }}
+      />
+      <div className="split-pane__pane">{children[1]}</div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable SplitPane component that provides draggable dividers
- integrate split panes so the tree/editor and hex view panes can be resized, including responsive handling
- refresh layout and editor styles to accommodate the new split panes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc68b1e2c48331946ca18fde7b3618