### PR TITLE
Ensure split panes stretch to viewport

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -45,6 +45,7 @@
   flex: 1;
   display: flex;
   overflow: hidden;
+  min-height: 0;
 }
 
 .split-pane {
@@ -64,6 +65,11 @@
   overflow: hidden;
   display: flex;
   flex-direction: column;
+}
+
+.split-pane__pane > * {
+  flex: 1;
+  min-height: 0;
 }
 
 .split-pane__divider {
@@ -109,11 +115,17 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  min-height: 0;
 }
 
 .left-pane {
   border-right: 1px solid var(--panel-border);
   background: var(--panel-bg);
+}
+
+.left-pane > .split-pane {
+  flex: 1;
+  min-height: 0;
 }
 
 .left-pane--stacked {
@@ -266,6 +278,8 @@
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+  flex: 1;
+  min-height: 0;
 }
 
 .ksy-editor textarea {
@@ -293,6 +307,7 @@
   flex-direction: column;
   padding: 1rem;
   gap: 0.75rem;
+  min-height: 0;
 }
 
 .hex-pane__toolbar {
@@ -326,6 +341,7 @@
   border-radius: 8px;
   background: rgba(0, 0, 0, 0.4);
   overflow: auto;
+  min-height: 0;
 }
 
 .hex-pane__list--virtual {


### PR DESCRIPTION
## Summary
- let split pane children flex to fill the available track height so the nested KSY editor reaches the window bottom
- reset the left and right pane min-heights so their contents can shrink and expose scrollbars when needed

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc6cf3fc70833188bf48ae00a327fe