### PR TITLE
Adjust tree node toggle layout

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -187,7 +187,16 @@
   margin-bottom: 0.1rem;
 }
 
+.tree-node__header {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
 .tree-node__toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   width: 1.5rem;
   height: 1.5rem;
   border: none;

--- a/app/src/components/TreePanel.tsx
+++ b/app/src/components/TreePanel.tsx
@@ -16,18 +16,20 @@ function NodeItem({ node, depth }: { node: AstNode; depth: number }) {
 
   return (
     <div className="tree-node" style={{ paddingLeft: depth * 12 }}>
-      {hasChildren && (
-        <button className="tree-node__toggle" onClick={() => setExpanded((prev) => !prev)}>
-          {expanded ? "▼" : "▶"}
+      <div className="tree-node__header">
+        {hasChildren && (
+          <button className="tree-node__toggle" onClick={() => setExpanded((prev) => !prev)}>
+            {expanded ? "▼" : "▶"}
+          </button>
+        )}
+        {!hasChildren && <span className="tree-node__toggle" />}
+        <button
+          className={`tree-node__label ${isSelected ? "tree-node__label--selected" : ""}`}
+          onClick={() => selectNode(node)}
+        >
+          {node.name} <span className="tree-node__type">({node.typeName})</span>
         </button>
-      )}
-      {!hasChildren && <span className="tree-node__toggle" />}
-      <button
-        className={`tree-node__label ${isSelected ? "tree-node__label--selected" : ""}`}
-        onClick={() => selectNode(node)}
-      >
-        {node.name} <span className="tree-node__type">({node.typeName})</span>
-      </button>
+      </div>
       {hasChildren && expanded && (
         <div className="tree-node__children">
           {node.children?.map((child) => (


### PR DESCRIPTION
## Summary
- wrap each tree node's toggle and label in a header row to avoid line breaks
- update tree node styles so the toggle placeholder and label align horizontally without extra spacing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc82194468833199f64c2b93cf4afc