### PR TITLE
Fix header_section params list

### DIFF
--- a/ksy/kfx.ksy
+++ b/ksy/kfx.ksy
@@ -44,9 +44,9 @@ instances:
 types:
   header_section:
     params:
-      container_info_offset
-      container_info_length
-      header_len
+      - id: container_info_offset
+      - id: container_info_length
+      - id: header_len
     seq:
       - id: prefix_area
         type: pre_container_info


### PR DESCRIPTION
## Summary
- correct the header_section params definition so YAML parses it as a sequence of parameters

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd1e3353bc83318a7cc7a70167585c