### PR TITLE
Fix ExpressionParser constructor for erasable syntax

### DIFF
--- a/app/src/utils/kaitaiParser.ts
+++ b/app/src/utils/kaitaiParser.ts
@@ -66,12 +66,15 @@ function getDecoder(encoding: string | undefined): TextDecoder {
 
 class ExpressionParser {
   private index = 0;
+  private readonly expr: string;
+  private readonly env: ParseEnv;
+  private readonly ctx: ParseContext;
 
-  constructor(
-    private readonly expr: string,
-    private readonly env: ParseEnv,
-    private readonly ctx: ParseContext
-  ) {}
+  constructor(expr: string, env: ParseEnv, ctx: ParseContext) {
+    this.expr = expr;
+    this.env = env;
+    this.ctx = ctx;
+  }
 
   parse(): number | undefined {
     try {


### PR DESCRIPTION
## Summary
- replace parameter properties in `ExpressionParser` with explicit fields and constructor assignments to comply with `erasableSyntaxOnly`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd2914bb0c8331b630dada861464db