### PR TITLE
Fix Kaitai compiler stub to expose runtime

### DIFF
--- a/app/src/utils/kaitai-struct-compiler-js-fastopt.js
+++ b/app/src/utils/kaitai-struct-compiler-js-fastopt.js
@@ -1,1 +1,9 @@
+const MainJs = globalThis.MainJs;
+
+if (!MainJs) {
+  throw new Error(
+    "Kaitai compiler runtime (MainJs) is not loaded. Ensure 'kaitai-struct-compiler-js-fastopt.js' bundle is included before using Kaitai compilation."
+  );
+}
+
 export { MainJs };


### PR DESCRIPTION
## Summary
- ensure the Kaitai compiler stub defines MainJs from the global runtime so the production build succeeds

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce56b6b6848331ba42fe9c33a4edfd