### PR TITLE
Fix iconv-lite resolution for GitHub Pages build

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -17,6 +17,7 @@
       "devDependencies": {
         "@eslint/js": "^9.35.0",
         "@types/js-yaml": "^4.0.9",
+        "@types/node": "^24.5.2",
         "@types/react": "^19.1.13",
         "@types/react-dom": "^19.1.9",
         "@vitejs/plugin-react": "^5.0.2",
@@ -1413,6 +1414,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
+      "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.12.0"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.1.13",
@@ -3207,6 +3218,13 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
+      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/app/package.json
+++ b/app/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@eslint/js": "^9.35.0",
     "@types/js-yaml": "^4.0.9",
+    "@types/node": "^24.5.2",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
     "@vitejs/plugin-react": "^5.0.2",

--- a/app/src/shims/iconv-lite.ts
+++ b/app/src/shims/iconv-lite.ts
@@ -1,0 +1,62 @@
+const decoderCache = new Map<string, TextDecoder>();
+
+const encodingAliases: Record<string, string> = {
+  ascii: "iso-8859-1",
+  us_ascii: "iso-8859-1",
+  utf8: "utf-8",
+  utf_8: "utf-8",
+  ucs2: "utf-16le",
+  ucs_2: "utf-16le",
+  utf16le: "utf-16le",
+  utf_16le: "utf-16le",
+  utf16be: "utf-16be",
+  utf_16be: "utf-16be",
+};
+
+function normaliseEncoding(encoding?: string): string {
+  if (!encoding) {
+    return "utf-8";
+  }
+  const normalised = encoding.trim().toLowerCase();
+  const aliasKey = normalised.replace(/[^0-9a-z]+/g, "_");
+  return encodingAliases[aliasKey] ?? normalised;
+}
+
+function getDecoder(encoding: string): TextDecoder {
+  const key = encoding.toLowerCase();
+  let decoder = decoderCache.get(key);
+  if (!decoder) {
+    decoder = new TextDecoder(encoding as unknown as string, { fatal: false });
+    decoderCache.set(key, decoder);
+  }
+  return decoder;
+}
+
+function toUint8Array(value: Uint8Array | ArrayLike<number>): Uint8Array {
+  return value instanceof Uint8Array ? value : Uint8Array.from(value);
+}
+
+function decode(
+  buffer: Uint8Array | ArrayLike<number>,
+  encoding?: string
+): string {
+  const targetEncoding = normaliseEncoding(encoding);
+  const bytes = toUint8Array(buffer);
+  try {
+    return getDecoder(targetEncoding).decode(bytes);
+  } catch {
+    if (targetEncoding !== "utf-8") {
+      return getDecoder("utf-8").decode(bytes);
+    }
+    // Fallback to manual decoding to avoid crashing the viewer entirely.
+    let result = "";
+    for (let i = 0; i < bytes.length; i += 1) {
+      result += String.fromCharCode(bytes[i]);
+    }
+    return result;
+  }
+}
+
+export { decode };
+
+export default { decode };

--- a/app/tsconfig.app.json
+++ b/app/tsconfig.app.json
@@ -14,6 +14,10 @@
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
+    "baseUrl": "./",
+    "paths": {
+      "iconv-lite": ["src/shims/iconv-lite.ts"]
+    },
 
     /* Linting */
     "strict": true,

--- a/app/tsconfig.node.json
+++ b/app/tsconfig.node.json
@@ -12,6 +12,7 @@
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",
     "noEmit": true,
+    "types": ["node"],
 
     /* Linting */
     "strict": true,

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { fileURLToPath, URL } from 'node:url'
 
 const repository = (globalThis as typeof globalThis & {
   process?: { env?: Record<string, string | undefined> }
@@ -11,4 +12,11 @@ const base = repoName ? `/${repoName}/` : '/'
 export default defineConfig({
   base,
   plugins: [react()],
+  resolve: {
+    alias: {
+      'iconv-lite': fileURLToPath(
+        new URL('./src/shims/iconv-lite.ts', import.meta.url)
+      ),
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- add a lightweight TextDecoder-based shim to satisfy kaitai-struct's iconv-lite requirement in the browser
- alias iconv-lite to the shim for both Vite and TypeScript builds
- include @types/node so the Vite config can use node:url utilities

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce5c7f6d4c833199f36c8f974b3108