### PR TITLE
Fix Kaitai runtime loading in HexViewer

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "js-yaml": "^4.1.0",
         "kaitai-struct": "^0.10.0",
+        "kaitai-struct-compiler": "^0.11.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "zustand": "^5.0.8"
@@ -2594,6 +2595,12 @@
       "resolved": "https://registry.npmjs.org/kaitai-struct/-/kaitai-struct-0.10.0.tgz",
       "integrity": "sha512-81oxVi/OY+LrzgrONX7ciD1wtvq24nb2M9iYixRiQG+1hrDrDRqFVWuQzF1fUexh3Sg/ol6eMAz1MOVYFouzUg==",
       "license": "Apache-2.0"
+    },
+    "node_modules/kaitai-struct-compiler": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/kaitai-struct-compiler/-/kaitai-struct-compiler-0.11.0.tgz",
+      "integrity": "sha512-GJYIS7w8y6oh91GcDwUXMbbOhKzTQqMx4CXVw8iY12xJgCEEvYaoobgxMvi8XTzV/8uDSPYk5GP+Z/KfPuiEsA==",
+      "license": "GPL-3.0-or-later"
     },
     "node_modules/keyv": {
       "version": "4.5.4",

--- a/app/package.json
+++ b/app/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "js-yaml": "^4.1.0",
     "kaitai-struct": "^0.10.0",
+    "kaitai-struct-compiler": "^0.11.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "zustand": "^5.0.8"

--- a/app/src/shims-kaitai-struct-compiler.d.ts
+++ b/app/src/shims-kaitai-struct-compiler.d.ts
@@ -1,0 +1,17 @@
+declare module "kaitai-struct-compiler" {
+  interface KaitaiStructCompilerImporter {
+    importYaml(name: string, mode: string): Promise<unknown>;
+  }
+
+  interface KaitaiStructCompilerApi {
+    compile(
+      target: string,
+      schema: unknown,
+      importer: KaitaiStructCompilerImporter,
+      includeDebugInfo: boolean
+    ): Promise<Record<string, string>>;
+  }
+
+  const compiler: KaitaiStructCompilerApi;
+  export default compiler;
+}

--- a/app/src/utils/kaitai-struct-compiler-js-fastopt.d.ts
+++ b/app/src/utils/kaitai-struct-compiler-js-fastopt.d.ts
@@ -1,5 +1,0 @@
-declare const MainJs: {
-  compile: (...args: unknown[]) => Promise<Record<string, string>>;
-};
-
-export { MainJs };

--- a/app/src/utils/kaitai-struct-compiler-js-fastopt.js
+++ b/app/src/utils/kaitai-struct-compiler-js-fastopt.js
@@ -1,9 +1,0 @@
-const MainJs = globalThis.MainJs;
-
-if (!MainJs) {
-  throw new Error(
-    "Kaitai compiler runtime (MainJs) is not loaded. Ensure 'kaitai-struct-compiler-js-fastopt.js' bundle is included before using Kaitai compilation."
-  );
-}
-
-export { MainJs };

--- a/app/src/utils/kaitaiCompiler.ts
+++ b/app/src/utils/kaitaiCompiler.ts
@@ -1,5 +1,5 @@
 import yaml from "js-yaml";
-import { MainJs } from "./kaitai-struct-compiler-js-fastopt.js";
+import KaitaiStructCompiler from "kaitai-struct-compiler";
 
 export interface KaitaiImporter {
   importYaml(name: string, mode: string): Promise<unknown>;
@@ -65,7 +65,7 @@ export async function compileKsySource(
   const schema = parsed as KaitaiSchema;
 
   try {
-    const files = (await MainJs.compile(
+    const files = (await KaitaiStructCompiler.compile(
       "javascript",
       schema,
       importer,


### PR DESCRIPTION
## Summary
- replace the manual Kaitai compiler runtime shim with the published `kaitai-struct-compiler` package
- add module typings so TypeScript can import the compiler without custom globals

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce7b60678083319196a0384fa7986a