### PR TITLE
Fix raw bytes parsing for CONT container

### DIFF
--- a/ksy/kfx.ksy
+++ b/ksy/kfx.ksy
@@ -37,7 +37,6 @@ types:
       - id: container_info_length
         type: u4
       - id: rest
-        type: bytes
         size: header_length - _root._io.pos - 14
   # ---- Generic Amazon Ion binary ----
   ion_stream:


### PR DESCRIPTION
## Summary
- fix the CONT container stub by reading the remaining header bytes as raw data without referencing a nonexistent `bytes` type

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce99bb9a48833185dfa870a9ddad26