### PR TITLE
Fix Ion repr size check for optional length

### DIFF
--- a/ksy/kfx.ksy
+++ b/ksy/kfx.ksy
@@ -66,7 +66,7 @@ types:
 
     instances:
       repr_size:
-        value: "(td.len_nibble < 0xE ? td.len_nibble : (td.len_nibble == 0xE ? (length ? length.value : 0) : 0))"
+        value: "(td.len_nibble < 0xE ? td.len_nibble : (td.len_nibble == 0xE ? ((length != null) ? length.value : 0) : 0))"
 
   ion_container_stream:
     seq:


### PR DESCRIPTION
## Summary
- fix repr_size calculation to explicitly guard against missing optional length fields in Ion values

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce9c7bf3fc83318a245ae88612c287