### PR TITLE
Fix ion repr size computation when length absent

### DIFF
--- a/ksy/kfx.ksy
+++ b/ksy/kfx.ksy
@@ -66,7 +66,11 @@ types:
 
     instances:
       repr_size:
-        value: "(td.len_nibble < 0xE ? td.len_nibble : (td.len_nibble == 0xE ? ((length != null) ? length.value : 0) : 0))"
+        value: (td.len_nibble < 0xE
+          ? td.len_nibble
+          : (td.len_nibble == 0xE
+            ? (td.is_nop ? 0 : length.value)
+            : 0))
 
   ion_container_stream:
     seq:


### PR DESCRIPTION
## Summary
- guard the Amazon Ion repr size calculation against missing length fields
- avoid referencing a null placeholder by checking the type descriptor instead

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce9dbc107083319f7edfab55c6b432