### PR TITLE
Fix CONT rest size to avoid negative typed array length

### DIFF
--- a/ksy/kfx.ksy
+++ b/ksy/kfx.ksy
@@ -37,7 +37,7 @@ types:
       - id: container_info_length
         type: u4
       - id: rest
-        size: header_length - _root._io.pos - 14
+        size: "(header_length > _io.pos ? header_length - _io.pos : 0)"
   # ---- Generic Amazon Ion binary ----
   ion_stream:
     doc: Concatenation of Ion values until EOF.


### PR DESCRIPTION
## Summary
- ensure CONT container remainder uses the substream position when computing its size

## Testing
- `node <<'NODE'
const path = require('path');
process.env.NODE_PATH = path.resolve('app/node_modules');
require('module').Module._initPaths();
const fs = require('fs');
const KaitaiStream = require('kaitai-struct/KaitaiStream');
const Kfx = require('./build_js/Kfx');
const filePath = path.join(__dirname, 'sample_data', 'map (10)_A6D8A4D1646845A5BB99504FB337265D.kfx');
const data = fs.readFileSync(filePath);
const ks = new KaitaiStream(data);
const parsed = new Kfx.Kfx(ks);
console.log('Parsed top-level type:', parsed.body.constructor.name);
console.log('Version:', parsed.body.version);
console.log('Header length:', parsed.body.headerLength);
console.log('Rest bytes:', parsed.body.rest.length);
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68cebaf5c154833195720109a9d98e07