### PR TITLE
Fix Kaitai debug range offsets

### DIFF
--- a/app/src/utils/kaitaiParser.ts
+++ b/app/src/utils/kaitaiParser.ts
@@ -132,8 +132,11 @@ function createModuleCache(files: Record<string, string>): ModuleCache {
 }
 
 function toRange(entry: DebugEntry | undefined): Range {
-  const start = entry?.start ?? 0;
-  const end = entry?.end ?? start;
+  const base = entry?.ioOffset ?? 0;
+  const relativeStart = entry?.start ?? 0;
+  const relativeEnd = entry?.end ?? relativeStart;
+  const start = base + relativeStart;
+  const end = base + relativeEnd;
   const length = Math.max(0, end - start);
   return { start, length };
 }


### PR DESCRIPTION
## Summary
- adjust Kaitai debug range conversion to include absolute offsets from ioOffset
- ensure nested structure selections highlight the correct byte ranges in the hex view

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cecd0794e88331973523bc4a86facf