### PR TITLE
Make KSY editor background white

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -299,8 +299,8 @@
   font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
     "Liberation Mono", "Courier New", monospace;
   font-size: 0.9rem;
-  background: rgba(0, 0, 0, 0.9);
-  color: inherit;
+  background: #ffffff;
+  color: #1d2330;
   border: 1px solid var(--panel-border);
   border-radius: 8px;
   padding: 0.75rem;


### PR DESCRIPTION
## Summary
- change the KSY editor textarea to use a white background and dark text for better readability

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ceeb9a35b48331a05eab89ee161f40