### PR TITLE
Remove undo/redo and session features

### DIFF
--- a/app/src/components/HexPane.tsx
+++ b/app/src/components/HexPane.tsx
@@ -1,10 +1,4 @@
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSessionStore } from "../state/sessionStore";
 import { useShallow } from "zustand/react/shallow";
 
@@ -20,32 +14,18 @@ function isPrintable(byte: number): boolean {
 }
 
 export function HexPane() {
-  const { buffer, selectedRange, selectRange, hexCols, editByte, caret } = useSessionStore(
+  const { buffer, selectedRange, selectRange, hexCols, caret } = useSessionStore(
     useShallow((state) => ({
       buffer: state.buffer,
       selectedRange: state.selectedRange,
       selectRange: state.selectRange,
       hexCols: state.hexCols,
-      editByte: state.editByte,
       caret: state.caret,
     })),
   );
-  const [hexInput, setHexInput] = useState("");
-  const [asciiInput, setAsciiInput] = useState("");
   const [scrollTop, setScrollTop] = useState(0);
   const [viewportHeight, setViewportHeight] = useState(480);
   const containerRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    if (!buffer || caret === null) {
-      setHexInput("");
-      setAsciiInput("");
-      return;
-    }
-    const byte = buffer[caret];
-    setHexInput(formatHex(byte));
-    setAsciiInput(isPrintable(byte) ? String.fromCharCode(byte) : ".");
-  }, [buffer, caret]);
 
   useEffect(() => {
     const element = containerRef.current;
@@ -78,18 +58,6 @@ export function HexPane() {
     [selectRange]
   );
 
-  const commitHexEdit = useCallback(() => {
-    if (caret === null) return;
-    const parsed = parseInt(hexInput, 16);
-    if (Number.isNaN(parsed)) return;
-    editByte(caret, parsed);
-  }, [caret, editByte, hexInput]);
-
-  const commitAsciiEdit = useCallback(() => {
-    if (caret === null || !asciiInput) return;
-    editByte(caret, asciiInput.charCodeAt(0));
-  }, [asciiInput, caret, editByte]);
-
   const rangeLabel = useMemo(() => {
     if (!selectedRange) return "";
     const end =
@@ -108,38 +76,6 @@ export function HexPane() {
     <section className="hex-pane">
       <div className="hex-pane__toolbar">
         <span>{rangeLabel}</span>
-        {caret !== null && (
-          <div className="hex-pane__editor">
-            <label>
-              HEX
-              <input
-                value={hexInput}
-                onChange={(e) => setHexInput(e.target.value.toUpperCase())}
-                onBlur={commitHexEdit}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    commitHexEdit();
-                  }
-                }}
-                maxLength={2}
-              />
-            </label>
-            <label>
-              ASCII
-              <input
-                value={asciiInput}
-                onChange={(e) => setAsciiInput(e.target.value.slice(0, 1))}
-                onBlur={commitAsciiEdit}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    commitAsciiEdit();
-                  }
-                }}
-                maxLength={1}
-              />
-            </label>
-          </div>
-        )}
       </div>
       {buffer ? (
         <div

--- a/app/src/components/TopBar.tsx
+++ b/app/src/components/TopBar.tsx
@@ -27,14 +27,9 @@ seq:
 
 export function TopBar() {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const sessionInputRef = useRef<HTMLInputElement | null>(null);
   const {
     loadFile,
     applyKsy,
-    undo,
-    redo,
-    saveSession,
-    restoreSession,
     setBuffer,
     setKsySource,
     ksySource,
@@ -46,10 +41,6 @@ export function TopBar() {
     useShallow((state) => ({
       loadFile: state.loadFile,
       applyKsy: state.applyKsy,
-      undo: state.undo,
-      redo: state.redo,
-      saveSession: state.saveSession,
-      restoreSession: state.restoreSession,
       setBuffer: state.setBuffer,
       setKsySource: state.setKsySource,
       ksySource: state.ksySource,
@@ -64,28 +55,6 @@ export function TopBar() {
     const file = event.target.files?.[0];
     if (!file) return;
     await loadFile(file);
-  };
-
-  const handleSessionSave = () => {
-    const session = saveSession();
-    if (!session) return;
-    const blob = new Blob([JSON.stringify(session, null, 2)], {
-      type: "application/json",
-    });
-    const url = URL.createObjectURL(blob);
-    const anchor = document.createElement("a");
-    anchor.href = url;
-    anchor.download = `${session.fileMeta?.name ?? "session"}.json`;
-    anchor.click();
-    URL.revokeObjectURL(url);
-  };
-
-  const handleSessionLoad = async (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
-    if (!file) return;
-    const text = await file.text();
-    const session = JSON.parse(text);
-    await restoreSession(session);
   };
 
   const handleLoadSample = async () => {
@@ -122,18 +91,6 @@ export function TopBar() {
             <option value={32}>32</option>
           </select>
         </label>
-        <button onClick={undo}>Undo</button>
-        <button onClick={redo}>Redo</button>
-      </div>
-      <div className="top-bar__section">
-        <button onClick={handleSessionSave}>セッション保存</button>
-        <button onClick={() => sessionInputRef.current?.click()}>セッション読込</button>
-        <input
-          ref={sessionInputRef}
-          type="file"
-          style={{ display: "none" }}
-          onChange={handleSessionLoad}
-        />
       </div>
       <div className="top-bar__meta">
         {fileMeta ? (

--- a/app/src/state/sessionStore.ts
+++ b/app/src/state/sessionStore.ts
@@ -1,13 +1,6 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
-import type {
-  Annotation,
-  AstNode,
-  ParseResult,
-  Range,
-  SessionData,
-  SessionFileMeta,
-} from "../types";
+import type { Annotation, AstNode, ParseResult, Range, SessionFileMeta } from "../types";
 import { parseWithKsy } from "../utils/kaitaiParser";
 
 interface SessionState {
@@ -20,8 +13,6 @@ interface SessionState {
   caret: number | null;
   selectedNodeId: string | null;
   selectedRange: Range | null;
-  history: Uint8Array[];
-  future: Uint8Array[];
   isParsing: boolean;
   parseToken: symbol | null;
   errors: string[];
@@ -33,10 +24,6 @@ interface SessionState {
   selectRange: (range: Range | null) => void;
   setHexCols: (cols: 16 | 24 | 32) => void;
   editByte: (offset: number, value: number) => void;
-  undo: () => void;
-  redo: () => void;
-  saveSession: () => SessionData | null;
-  restoreSession: (session: SessionData) => Promise<void>;
 }
 
 async function hashBuffer(buffer: ArrayBuffer): Promise<string> {
@@ -61,8 +48,6 @@ export const useSessionStore = create<SessionState>()(
       caret: null,
       selectedNodeId: null,
       selectedRange: null,
-      history: [],
-      future: [],
       isParsing: false,
       errors: [],
       parseToken: null,
@@ -80,7 +65,7 @@ export const useSessionStore = create<SessionState>()(
 
       setBuffer: async (data: Uint8Array, meta?: SessionFileMeta | null) => {
         const cloned = cloneBuffer(data);
-        set({ buffer: cloned, fileMeta: meta ?? get().fileMeta, history: [], future: [] });
+        set({ buffer: cloned, fileMeta: meta ?? get().fileMeta });
         if (get().ksySource.trim()) {
           await get().applyKsy();
         } else {
@@ -176,75 +161,9 @@ export const useSessionStore = create<SessionState>()(
         const clamped = value & 0xff;
         const newBuffer = cloneBuffer(buffer);
         newBuffer[offset] = clamped;
-        set((state) => ({ history: [...state.history, cloneBuffer(buffer)], future: [] }));
         set({ buffer: newBuffer });
         if (get().ksySource.trim()) {
           void get().applyKsy();
-        }
-      },
-
-      undo: () => {
-        const history = get().history;
-        if (history.length === 0) return;
-        const buffer = get().buffer;
-        const prev = history[history.length - 1];
-        set({
-          buffer: cloneBuffer(prev),
-          history: history.slice(0, -1),
-          future: buffer ? [cloneBuffer(buffer), ...get().future] : get().future,
-        });
-        if (get().ksySource.trim()) {
-          void get().applyKsy();
-        }
-      },
-
-      redo: () => {
-        const future = get().future;
-        if (future.length === 0) return;
-        const buffer = get().buffer;
-        const next = future[0];
-        set({
-          buffer: cloneBuffer(next),
-          future: future.slice(1),
-          history: buffer ? [...get().history, cloneBuffer(buffer)] : get().history,
-        });
-        if (get().ksySource.trim()) {
-          void get().applyKsy();
-        }
-      },
-
-      saveSession: () => {
-        const { buffer, fileMeta, ksySource, annotations, hexCols, caret } = get();
-        if (!buffer) return null;
-        const session: SessionData = {
-          fileMeta,
-          bufferBase64: btoa(String.fromCharCode(...buffer)),
-          ksySource,
-          annotations,
-          viewState: {
-            hexCols,
-            caret,
-          },
-        };
-        return session;
-      },
-
-      restoreSession: async (session: SessionData) => {
-        const buffer = session.bufferBase64
-          ? Uint8Array.from(atob(session.bufferBase64), (c) => c.charCodeAt(0))
-          : null;
-        set({
-          buffer,
-          fileMeta: session.fileMeta ?? null,
-          ksySource: session.ksySource ?? "",
-          annotations: session.annotations ?? [],
-          hexCols: session.viewState.hexCols ?? 16,
-          caret: session.viewState.caret ?? null,
-          history: [],
-          future: [],
-        });
-        if (buffer && session.ksySource) {
-          await get().applyKsy(session.ksySource);
         }
       },
     }),


### PR DESCRIPTION
## Summary
- remove undo/redo and session load/save controls from the top bar
- simplify the session store by dropping history-based undo/redo and session persistence helpers
- eliminate hex/ASCII inline editors from the hex pane UI

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ceed41ab9083318e6518ff4e7b0aaf