### PR TITLE
Add address jump controls to hex pane

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -327,6 +327,42 @@
   font-size: 0.95rem;
 }
 
+.hex-pane__controls {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.hex-pane__jump {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.hex-pane__jump label {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.hex-pane__jump input[type="text"] {
+  width: 6rem;
+  text-transform: uppercase;
+}
+
+.hex-pane__jump-base {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+}
+
+.hex-pane__jump-base label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
 .hex-pane__editor {
   display: flex;
   align-items: center;

--- a/app/src/components/HexPane.tsx
+++ b/app/src/components/HexPane.tsx
@@ -1,4 +1,5 @@
 import {
+  type FormEvent,
   useCallback,
   useEffect,
   useMemo,
@@ -32,6 +33,8 @@ export function HexPane() {
   );
   const [hexInput, setHexInput] = useState("");
   const [asciiInput, setAsciiInput] = useState("");
+  const [addressInput, setAddressInput] = useState("");
+  const [addressBase, setAddressBase] = useState<"hex" | "dec">("hex");
   const [scrollTop, setScrollTop] = useState(0);
   const [viewportHeight, setViewportHeight] = useState(480);
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -40,12 +43,24 @@ export function HexPane() {
     if (!buffer || caret === null) {
       setHexInput("");
       setAsciiInput("");
+      setAddressInput("");
       return;
     }
     const byte = buffer[caret];
     setHexInput(formatHex(byte));
     setAsciiInput(isPrintable(byte) ? String.fromCharCode(byte) : ".");
   }, [buffer, caret]);
+
+  useEffect(() => {
+    if (caret === null) {
+      return;
+    }
+    setAddressInput(
+      addressBase === "hex"
+        ? caret.toString(16).toUpperCase()
+        : caret.toString(10),
+    );
+  }, [addressBase, caret]);
 
   useEffect(() => {
     const element = containerRef.current;
@@ -65,6 +80,21 @@ export function HexPane() {
     setScrollTop(0);
   }, [buffer]);
 
+  useEffect(() => {
+    const element = containerRef.current;
+    if (!element || caret === null) return;
+    const rowIndex = Math.floor(caret / hexCols);
+    const rowTop = rowIndex * ROW_HEIGHT;
+    const rowBottom = rowTop + ROW_HEIGHT;
+    const currentTop = element.scrollTop;
+    const currentBottom = currentTop + viewportHeight;
+    if (rowTop < currentTop) {
+      element.scrollTop = rowTop;
+    } else if (rowBottom > currentBottom) {
+      element.scrollTop = Math.max(rowBottom - viewportHeight, 0);
+    }
+  }, [caret, hexCols, viewportHeight]);
+
   const rowCount = buffer ? Math.ceil(buffer.length / hexCols) : 0;
   const totalHeight = rowCount * ROW_HEIGHT;
   const visibleRowCount = Math.ceil(viewportHeight / ROW_HEIGHT);
@@ -76,6 +106,47 @@ export function HexPane() {
       selectRange({ start: index, length: 1 });
     },
     [selectRange]
+  );
+
+  const parseAddress = useCallback(
+    (value: string, base: "hex" | "dec"): number | null => {
+      const trimmed = value.trim();
+      if (!trimmed) return null;
+      const parsed = Number.parseInt(trimmed, base === "hex" ? 16 : 10);
+      return Number.isNaN(parsed) ? null : parsed;
+    },
+    []
+  );
+
+  const handleAddressBaseChange = useCallback(
+    (base: "hex" | "dec") => {
+      setAddressBase((prevBase) => {
+        if (prevBase === base) return prevBase;
+        setAddressInput((prevInput) => {
+          const parsed = parseAddress(prevInput, prevBase);
+          if (parsed === null) {
+            return "";
+          }
+          return base === "hex"
+            ? parsed.toString(16).toUpperCase()
+            : parsed.toString(10);
+        });
+        return base;
+      });
+    },
+    [parseAddress]
+  );
+
+  const handleJump = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (!buffer) return;
+      const parsed = parseAddress(addressInput, addressBase);
+      if (parsed === null) return;
+      if (parsed < 0 || parsed >= buffer.length) return;
+      selectRange({ start: parsed, length: 1 });
+    },
+    [addressBase, addressInput, buffer, parseAddress, selectRange]
   );
 
   const commitHexEdit = useCallback(() => {
@@ -108,38 +179,77 @@ export function HexPane() {
     <section className="hex-pane">
       <div className="hex-pane__toolbar">
         <span>{rangeLabel}</span>
-        {caret !== null && (
-          <div className="hex-pane__editor">
+        <div className="hex-pane__controls">
+          <form className="hex-pane__jump" onSubmit={handleJump}>
             <label>
-              HEX
+              アドレス
               <input
-                value={hexInput}
-                onChange={(e) => setHexInput(e.target.value.toUpperCase())}
-                onBlur={commitHexEdit}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    commitHexEdit();
-                  }
+                type="text"
+                value={addressInput}
+                onChange={(event) => {
+                  const value = event.target.value;
+                  setAddressInput(addressBase === "hex" ? value.toUpperCase() : value);
                 }}
-                maxLength={2}
+                placeholder={addressBase === "hex" ? "0" : "0"}
               />
             </label>
-            <label>
-              ASCII
-              <input
-                value={asciiInput}
-                onChange={(e) => setAsciiInput(e.target.value.slice(0, 1))}
-                onBlur={commitAsciiEdit}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    commitAsciiEdit();
-                  }
-                }}
-                maxLength={1}
-              />
-            </label>
-          </div>
-        )}
+            <div className="hex-pane__jump-base">
+              <label>
+                <input
+                  type="radio"
+                  name="jump-base"
+                  value="hex"
+                  checked={addressBase === "hex"}
+                  onChange={() => handleAddressBaseChange("hex")}
+                />
+                Hex
+              </label>
+              <label>
+                <input
+                  type="radio"
+                  name="jump-base"
+                  value="dec"
+                  checked={addressBase === "dec"}
+                  onChange={() => handleAddressBaseChange("dec")}
+                />
+                Dec
+              </label>
+            </div>
+            <button type="submit">ジャンプ</button>
+          </form>
+          {caret !== null && (
+            <div className="hex-pane__editor">
+              <label>
+                HEX
+                <input
+                  value={hexInput}
+                  onChange={(e) => setHexInput(e.target.value.toUpperCase())}
+                  onBlur={commitHexEdit}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      commitHexEdit();
+                    }
+                  }}
+                  maxLength={2}
+                />
+              </label>
+              <label>
+                ASCII
+                <input
+                  value={asciiInput}
+                  onChange={(e) => setAsciiInput(e.target.value.slice(0, 1))}
+                  onBlur={commitAsciiEdit}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      commitAsciiEdit();
+                    }
+                  }}
+                  maxLength={1}
+                />
+              </label>
+            </div>
+          )}
+        </div>
       </div>
       {buffer ? (
         <div


### PR DESCRIPTION
## Summary
- add an address input with hex/dec toggles in the binary dump pane
- scroll to and select the requested byte when jumping to an address
- align new controls with existing caret editing inputs

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ceedcd55dc8331817d634cc2e285c5