### PR TITLE
Remove redundant reparse button from KSY editor

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -294,7 +294,7 @@
 .ksy-editor textarea {
   width: 100%;
   flex: 1;
-  min-height: 0;
+  min-height: 240px;
   resize: none;
   font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
     "Liberation Mono", "Courier New", monospace;
@@ -304,10 +304,6 @@
   border: 1px solid var(--panel-border);
   border-radius: 8px;
   padding: 0.75rem;
-}
-
-.ksy-editor button {
-  align-self: flex-start;
 }
 
 .hex-pane {

--- a/app/src/components/KsyEditor.tsx
+++ b/app/src/components/KsyEditor.tsx
@@ -2,11 +2,10 @@ import { useSessionStore } from "../state/sessionStore";
 import { useShallow } from "zustand/react/shallow";
 
 export function KsyEditor() {
-  const { ksySource, setKsySource, applyKsy } = useSessionStore(
+  const { ksySource, setKsySource } = useSessionStore(
     useShallow((state) => ({
       ksySource: state.ksySource,
       setKsySource: state.setKsySource,
-      applyKsy: state.applyKsy,
     })),
   );
 
@@ -19,9 +18,6 @@ export function KsyEditor() {
         spellCheck={false}
         placeholder="KSY (YAML) を貼り付けてください"
       />
-      <button onClick={() => applyKsy()} disabled={!ksySource.trim()}>
-        再パース
-      </button>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- remove the duplicate reparse button from the KSY editor panel
- give the KSY editor textarea a taller minimum height so the input area is easier to use

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ceeeb0ebf883319f9cb1906dc331da