### PR TITLE
Adjust panel spacing for denser layout

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -141,15 +141,15 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  padding: 1rem;
+  padding: 0.65rem 0.75rem;
   overflow: hidden;
 }
 
 .tree-panel h2,
 .ksy-editor h2 {
-  margin: 0 0 0.5rem 0;
-  font-size: 1rem;
-  letter-spacing: 0.04em;
+  margin: 0 0 0.35rem 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.03em;
   text-transform: uppercase;
   color: var(--muted);
 }
@@ -172,7 +172,7 @@
 
 .tree-panel__tree {
   overflow: auto;
-  padding: 0.4rem;
+  padding: 0.3rem;
 }
 
 .tree-panel__empty {
@@ -244,13 +244,13 @@
 
 .tree-panel__details {
   overflow: auto;
-  padding: 0.75rem;
+  padding: 0.55rem 0.65rem;
   background: rgba(0, 0, 0, 0.2);
   border-top: 1px solid var(--panel-border);
 }
 
 .node-details h3 {
-  margin: 0 0 0.5rem 0;
+  margin: 0 0 0.4rem 0;
 }
 
 .node-details__grid {
@@ -281,12 +281,12 @@
 }
 
 .ksy-editor {
-  padding: 1rem;
+  padding: 0.75rem;
   border-top: 1px solid var(--panel-border);
   background: rgba(0, 0, 0, 0.18);
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.5rem;
   flex: 1;
   min-height: 0;
 }
@@ -303,7 +303,7 @@
   color: #1d2330;
   border: 1px solid var(--panel-border);
   border-radius: 8px;
-  padding: 0.75rem;
+  padding: 0.55rem 0.65rem;
 }
 
 .ksy-editor button {
@@ -314,8 +314,8 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  padding: 1rem;
-  gap: 0.75rem;
+  padding: 0.75rem;
+  gap: 0.55rem;
   min-height: 0;
 }
 


### PR DESCRIPTION
## Summary
- tighten padding and heading spacing for the structure tree and KSY editor panels to maximise content area
- shrink textarea padding and related gaps for a denser editor layout
- reduce hex pane padding to keep the selection label compact

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ceef48aa2c83319c67f5a57440ca5b