### PR TITLE
Fix missing root-level instances in Kaitai parser tree

### DIFF
--- a/app/src/utils/kaitaiCompiler.ts
+++ b/app/src/utils/kaitaiCompiler.ts
@@ -13,6 +13,7 @@ export interface KaitaiSchema {
   };
   seq?: KaitaiFieldSpec[];
   types?: Record<string, KaitaiTypeSpec>;
+  instances?: Record<string, KaitaiInstanceSpec>;
 }
 
 export interface KaitaiFieldSpec {

--- a/app/src/utils/kaitaiParser.ts
+++ b/app/src/utils/kaitaiParser.ts
@@ -635,6 +635,7 @@ export async function parseWithKsy(
   const rootSpec: KaitaiTypeSpec = {
     seq: schema.seq ?? [],
     types: schema.types ?? {},
+    instances: schema.instances ?? {},
   };
   const className = toPascalCase(schema.meta?.id ?? "root");
   const moduleName = `${className}.js`;


### PR DESCRIPTION
## Summary
- extend the Kaitai schema type so the root-level instances section is preserved
- include parsed instance definitions when constructing the root type spec so instance nodes appear in the tree

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf1bf5cf608331940720f5377369f8