### PR TITLE
Adjust tree indentation spacing

### DIFF
--- a/app/src/components/TreePanel.tsx
+++ b/app/src/components/TreePanel.tsx
@@ -15,7 +15,7 @@ function NodeItem({ node, depth }: { node: AstNode; depth: number }) {
   const isSelected = selectedNodeId === node.id;
 
   return (
-    <div className="tree-node" style={{ paddingLeft: depth * 12 }}>
+    <div className="tree-node" style={{ paddingLeft: depth * 6 }}>
       <div className="tree-node__header">
         {hasChildren && (
           <button className="tree-node__toggle" onClick={() => setExpanded((prev) => !prev)}>


### PR DESCRIPTION
## Summary
- reduce structural tree indentation spacing to make nested nodes easier to read

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cfdde75c888331ad0eb149ad08db21